### PR TITLE
Fix flaky test.

### DIFF
--- a/src/zope/paste/tests.py
+++ b/src/zope/paste/tests.py
@@ -129,12 +129,12 @@ def test_serving_test_app():
 
     >>> import logging
     >>> logger = logging.getLogger('waitress')
-    >>> logger.addHandler(logging.StreamHandler(sys.stdout))
+    >>> handler = logging.StreamHandler(sys.stdout)
+    >>> logger.addHandler(handler)
     >>> logger.setLevel(logging.INFO)
 
     Start the app:
 
-    >>> import os
     >>> import os.path
     >>> import threading
     >>> from zope.paste import serve
@@ -153,6 +153,7 @@ def test_serving_test_app():
 
     >>> _ = [asyncore.close_all(obj._map)
     ...      for obj in gc.get_objects() if isinstance(obj, WSGIServer)]
+    >>> logger.removeHandler(handler)
     """
 
 

--- a/src/zope/paste/tests.py
+++ b/src/zope/paste/tests.py
@@ -128,7 +128,7 @@ def test_serving_test_app():
     >>> from zope.paste import serve
     >>> server = threading.Thread(target=serve.serve, args=(['app.ini'],))
     >>> server.start()
-    >>> import time; time.sleep(5)  # doctest: +ELLIPSIS
+    >>> import time; time.sleep(10)  # doctest: +ELLIPSIS
     Serving on http://localhost:...
 
     >>> print(urlopen('http://localhost:{}/'.format(PORT)).read().decode())

--- a/src/zope/paste/tests.py
+++ b/src/zope/paste/tests.py
@@ -138,7 +138,7 @@ def test_serving_test_app():
     >>> import os.path
     >>> import threading
     >>> from zope.paste import serve
-    >>> app_ini = os.path.join(os.getcwd(), 'app.ini')
+    >>> app_ini = os.path.abspath('app.ini')
     >>> server = threading.Thread(target=serve.serve, args=([app_ini],))
     >>> server.start()
     >>> import time; time.sleep(5)  # doctest: +ELLIPSIS

--- a/src/zope/paste/tests.py
+++ b/src/zope/paste/tests.py
@@ -124,14 +124,27 @@ def test_basic_serve():
 def test_serving_test_app():
     """Test serving a real app.
 
+    Setup logging, so we get the message ``Serving on ...`` into our doctest
+    output:
+
+    >>> import logging
+    >>> logger = logging.getLogger('waitress')
+    >>> logger.addHandler(logging.StreamHandler(sys.stdout))
+    >>> logger.setLevel(logging.INFO)
+
+    Start the app:
+
+    >>> import os
+    >>> import os.path
     >>> import threading
     >>> from zope.paste import serve
-    >>> server = threading.Thread(target=serve.serve, args=(['app.ini'],))
+    >>> app_ini = os.path.join(os.getcwd(), 'app.ini')
+    >>> server = threading.Thread(target=serve.serve, args=([app_ini],))
     >>> server.start()
-    >>> import time; time.sleep(10)  # doctest: +ELLIPSIS
-    Serving on http://localhost:...
+    >>> import time; time.sleep(5)  # doctest: +ELLIPSIS
+    Serving on http://...
 
-    >>> print(urlopen('http://localhost:{}/'.format(PORT)).read().decode())
+    >>> print(urlopen('http://127.0.0.1:{}/'.format(PORT)).read().decode())
     <html>
       <body>
         <h1>Hello World, Zope App!</h1>


### PR DESCRIPTION
~~Wait longer to hopefully circumvent the problem.~~

This was not a flaky test problem but a problem with `waitress >= 2` and `zope.interface` not having a final 5.3.0 release.