### PR TITLE
Drop Python 2.7 and 3.5 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,7 +28,7 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml}]
+[*.{yml,zpt,pt,dtml,zcml}]
 # 2 space indentation
 indent_size = 2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,19 +26,20 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
+        - ["3.11",  "py311"]
         - ["3.9",   "coverage"]
 
     runs-on: ${{ matrix.os }}-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,18 +16,20 @@ jobs:
       # We want to see all failures:
       fail-fast: false
       matrix:
+        os:
+        - ubuntu
         config:
         # [Python version, tox env]
-        - ["3.8",   "lint"]
-        - ["2.7",   "py27"]
-        - ["3.5",   "py35"]
+        - ["3.9",   "lint"]
         - ["3.6",   "py36"]
         - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
-        - ["3.8",   "coverage"]
+        - ["3.10",  "py310"]
+        - ["3.9",   "coverage"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2
@@ -52,7 +54,7 @@ jobs:
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |
-        pip install coveralls coverage-python-version
+        pip install coveralls
         coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
+*.dll
 *.egg-info/
 *.profraw
 *.pyc
 *.pyo
+*.so
 .coverage
 .coverage.*
 .eggs/
@@ -26,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "0d2c351f0ed2233d91a4939ecc56be6f4850334c"
+commit-id = "9e96d80474deebd9f4a001b60c7da2682d925cdd"
 
 [python]
 with-pypy = false

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,14 +2,14 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "a42b1792f61e841423b04385d644c7e2d4581c1c"
+commit-id = "0d2c351f0ed2233d91a4939ecc56be6f4850334c"
 
 [python]
-with-appveyor = false
 with-pypy = false
-with-legacy-python = true
-with-docs = false
+with-legacy-python = false
 with-sphinx-doctests = false
+with-windows = false
+with-future-python = false
 
 [coverage]
 fail-under = 77

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change History
 1.1.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-- Add support for Python 3.6, 3.7, 3.8, 3.9.
+- Add support for Python 3.6, 3.7, 3.8, 3.9, 3.10.
+
+- Drop support for Python 2.7 and 3.5.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,9 @@ Change History
 1.1.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-- Add support for Python 3.6, 3.7, 3.8, 3.9, 3.10.
+- Add support for Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11.
 
 - Drop support for Python 2.7 and 3.5.
-
 
 
 1.0.0 (2017-01-04)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+<!--
+Generated from:
+https://github.com/zopefoundation/meta/tree/master/config/pure-python
+--> 
+# Contributing to zopefoundation projects
+
+The projects under the zopefoundation GitHub organization are open source and
+welcome contributions in different forms:
+
+* bug reports
+* code improvements and bug fixes
+* documentation improvements
+* pull request reviews
+
+For any changes in the repository besides trivial typo fixes you are required
+to sign the contributor agreement. See
+https://www.zope.dev/developer/becoming-a-committer.html for details.
+
+Please visit our [Developer
+Guidelines](https://www.zope.dev/developer/guidelines.html) if you'd like to
+contribute code changes and our [guidelines for reporting
+bugs](https://www.zope.dev/developer/reporting-bugs.html) if you want to file a
+bug report.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
+include *.md
 include *.rst
 include *.txt
 include buildout.cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [bdist_wheel]
-universal = 1
+universal = 0
 
 [flake8]
 doctests = 1
@@ -10,3 +10,14 @@ doctests = 1
 ignore =
     .editorconfig
     .meta.toml
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_third_party = six, docutils, pkg_resources
+known_zope =
+known_first_party =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: Implementation :: CPython',
             'Natural Language :: English',
             'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@
 """zope.paste - wsgi applications in zope 3 using paste.deploy
 """
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages
+from setuptools import setup
 
 
 def read_file(filename):
@@ -33,6 +35,7 @@ TEST_APP_REQUIRES = [
     'zope.security',
     'zope.site',
     'zope.traversing',
+    'zope.testrunner',
 ]
 setup(
     name="zope.paste",
@@ -53,14 +56,12 @@ setup(
             'Intended Audience :: Developers',
             'License :: OSI Approved :: Zope Public License',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: Implementation :: CPython',
             'Natural Language :: English',
             'Operating System :: OS Independent',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -15,4 +15,6 @@
 $Id$
 """
 import pkg_resources
+
+
 pkg_resources.declare_namespace('zope')

--- a/src/zope/paste/factory.py
+++ b/src/zope/paste/factory.py
@@ -14,11 +14,14 @@
 """Paste ``app_factory`` Entry Point.
 """
 import os.path
+
 import ZConfig
-import zope.event
+
 import zope.app.appsetup
+import zope.event
 from zope.app.appsetup.appsetup import multi_database
 from zope.app.wsgi import WSGIPublisherApplication
+
 
 _zope_app = None
 

--- a/src/zope/paste/serve.py
+++ b/src/zope/paste/serve.py
@@ -13,10 +13,11 @@
 ##############################################################################
 """Serve a Paste Application.
 """
-import paste.deploy
 import optparse
 import os.path
 import sys
+
+import paste.deploy
 
 
 parser = optparse.OptionParser("%prog [options] <paste-ini>")

--- a/src/zope/paste/test_app/view.py
+++ b/src/zope/paste/test_app/view.py
@@ -15,6 +15,7 @@
 """
 import os
 
+
 FAVICON_PATH = os.path.join(os.path.dirname(__file__), 'favicon.ico')
 
 

--- a/src/zope/paste/test_app/view.py
+++ b/src/zope/paste/test_app/view.py
@@ -19,7 +19,7 @@ import os
 FAVICON_PATH = os.path.join(os.path.dirname(__file__), 'favicon.ico')
 
 
-class FavIcon(object):
+class FavIcon:
 
     def __call__(self):
         self.request.response.setHeader('Content-Type', 'image/x-icon')
@@ -27,5 +27,5 @@ class FavIcon(object):
             return img.read()
 
 
-class HelloWorld(object):
+class HelloWorld:
     name = 'Zope App'

--- a/src/zope/paste/tests.py
+++ b/src/zope/paste/tests.py
@@ -25,6 +25,7 @@ import unittest
 import paste.deploy
 from waitress.server import WSGIServer
 
+
 try:
     from urllib.request import urlopen
 except ImportError:

--- a/src/zope/paste/tests.py
+++ b/src/zope/paste/tests.py
@@ -21,16 +21,11 @@ import shutil
 import sys
 import tempfile
 import unittest
+from urllib.request import urlopen
 
 import paste.deploy
 from waitress.server import WSGIServer
 
-
-try:
-    from urllib.request import urlopen
-except ImportError:
-    # PY2
-    from urllib2 import urlopen
 
 # let every Python version run on its own port to allow parallel runs:
 PORT = 8765 + 10 * sys.version_info.major + sys.version_info.minor

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py38
     py39
     py310
+    py311
     coverage
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,16 @@
 minversion = 3.18
 envlist =
     lint
-    py27
-    py35
     py36
     py37
     py38
     py39
+    py310
     coverage
 
 [testenv]
 usedevelop = true
 deps =
-    zope.testrunner
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -24,14 +22,25 @@ extras =
 [testenv:lint]
 basepython = python3
 skip_install = true
-deps =
-    flake8
-    check-manifest
-    check-python-versions
 commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 src setup.py
     check-manifest
     check-python-versions
+deps =
+    check-manifest
+    check-python-versions >= 0.19.1
+    wheel
+    flake8
+    isort
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
 
 [testenv:coverage]
 basepython = python3
@@ -39,8 +48,6 @@ allowlist_externals =
     mkdir
 deps =
     coverage
-    coverage-python-version
-    zope.testrunner
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
@@ -49,8 +56,7 @@ commands =
 
 [coverage:run]
 branch = True
-plugins = coverage_python_version
-source = src
+source = zope.paste
 
 [coverage:report]
 precision = 2


### PR DESCRIPTION
Update to current version of meta/config, which also adds Python 3.10 support.

Run tox -e isort-apply to make tox -e lint happy.

Disable with-legacy-python because paste.deploy no longer supports Python < 3.6.

Closes #5.